### PR TITLE
Removed unexpected parenthesis, so skpm can perform plugin build

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ function WebUI (context, frameLocation, options) {
 
   // When frameLocation is a file, prefix it with the Sketch Resources path
   if ((/^(?!http|localhost|www).*\.html?$/).test(frameLocation)) {
-    frameLocation = context.plugin.urlForResourceNamed(frameLocation).path())
+    frameLocation = context.plugin.urlForResourceNamed(frameLocation).path()
   }
   webView.setMainFrameURL_(frameLocation)
 


### PR DESCRIPTION
Hi,

I got that weird issue that I can't perform `skpm build` after I added `sketch-module-web-view` and trying to open new WebUI. Found out that it's because of this additional parenthesis 😄. Don't know how it was working before.

`Module parse failed: D:\dev\content-sketch-plugin\node_modules\sketch-module-web-view\lib\index.js Unexpected token (97:76).`

<details>
<pre>
> content-sketch-plugin@0.0.1 build D:\dev\content-sketch-plugin
> tsc && skpm build

[1/4] 🖨  Copied src/manifest.json in 8ms
error Error while building ./expo.js
./node_modules/sketch-module-web-view/lib/index.js
Module parse failed: D:\dev\content-sketch-plugin\node_modules\sketch-module-web-view\lib\index.js Unexpected
 token (97:76)
You may need an appropriate loader to handle this file type.
|   // When frameLocation is a file, prefix it with the Sketch Resources path
|   if ((/^(?!http|localhost|www).*\.html?$/).test(frameLocation)) {
|     frameLocation = context.plugin.urlForResourceNamed(frameLocation).path())
|   }
|   webView.setMainFrameURL_(frameLocation)
 @ ./src/views/login-new.js 6:27-60
 @ ./src/views/index.js
 @ ./src/expo.js</pre>
</details>