### PR TITLE
Expose close handler in WebUI

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ function WebUI (context, frameLocation, options) {
 
   // Close window callback
   var closeButton = panel.standardWindowButton(NSWindowCloseButton)
-  closeButton.setCOSJSTargetFunction(function (sender) {
+  var closeHandler = function() {
     if (options.onPanelClose) {
       var result = options.onPanelClose()
       if (result === false) {
@@ -94,7 +94,9 @@ function WebUI (context, frameLocation, options) {
     panel.close()
     threadDictionary.removeObjectForKey(options.identifier)
     coScript.setShouldKeepAround(false)
-  })
+  };
+
+  closeButton.setCOSJSTargetFunction(closeHandler)
   closeButton.setAction('callAction:')
 
   panel.setStyleMask(options.styleMask || (
@@ -181,7 +183,8 @@ function WebUI (context, frameLocation, options) {
   return {
     panel: panel,
     eval: webView.stringByEvaluatingJavaScriptFromString,
-    webView: webView
+    webView: webView,
+    close: closeHandler
   }
 }
 


### PR DESCRIPTION
Hi @mathieudutour! 

Found this issue while building the syntax highlighter plugin this weekend 😅

With this change, the webview panel can be closed from the plugin calling `webUIInstance.close()` and behave the same way when closed programmatically from the plugin than when closed from the native close button.

I would expose the method in the prototype of `WebUI`, but that would imply moving too many things around and first wanted to confirm if this change seems good to you :)

