### PR TITLE
Fix typo in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On the plugin:
 ```js
 browserWindow.webContents.on('nativeLog', function (s) {
   context.document.showMessage(s)
-}
+})
 ```
 
 On the webview:


### PR DESCRIPTION
I caught a typo in the readme.

With that being said, the entire snippet (calling plugin stuff from the webui) doesn't appear to work yet.