### PR TITLE
Improve acceptsFirstMouse hack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -221,7 +221,7 @@ function BrowserWindow (options) {
         var x = point.x
         var y = webView.frame().size.height - point.y
         browserWindow.webContents.executeJavaScript(
-          'document.elementFromPoint(' + x + ', ' + y + ').click()'
+          'var el = document.elementFromPoint(' + x + ', ' + y + '); if (["text", "textarea", "date", "datetime-local", "email", "number", "month", "password", "search", "tel", "time", "url", "week" ].indexOf(el.type) >= 0 && el.focus ) { el.focus(); } else { el.dispatchEvent(new Event("click", {bubbles: true})) }'
         )
       }
     })


### PR DESCRIPTION
This addresses two problems:

- When used on `<a>`, elementFromPoint returns the children, no the `<a>`. In some cases, like when the child is a svg `<path>` element which has no .click() method, this causes an error. By dispatching a click event from the element, we avoid the error and the event bubbles up to any listeners on the `<a>`

- In most cases, when using acceptsFirstMouse to click a text-based input, the expected behavior is actually .focus(). This checks if the element is an input type that one would expect to focus rather than click.

There are probably prettier ways to do this, so I'm open to suggestions. I didn't test it on every element in the list, but I did test it on buttons, textareas, text inputs, and links.