### PR TITLE
Reset `wasReady` when closing webview

### DIFF
--- a/lib/webview-api.js
+++ b/lib/webview-api.js
@@ -160,6 +160,7 @@ module.exports = function buildAPI (browserWindow, panel, webview) {
 
       // Called when a frame will be closed.
       'webView:willCloseFrame:': function (webView, webFrame) {
+        this.state.setObject_forKey(1, 'wasReady')
         this.utils.emit('will-prevent-unload', {
           preventDefault: function () {
             this.utils.close()


### PR DESCRIPTION
Since [FrameLoadDelegateClass is persistent](https://github.com/skpm/sketch-module-web-view/blob/electron-api/lib/webview-api.js#L7), we need to reset the ready state when the window is closed.

I discovered this when trying to create a panel which, once opened, will toggle visibility on and off on subsequent executions of the "show this panel" command. I noticed that if I turned it on, _closed it_, then toggled it one more time, when the window would open, it wouldn't initialize the panel because the ready state was stale from the previous webview.

This probably isn't the right solution. I would imagine a better solution would be to reset the _entire_ state rather than just this key, or switch to creating a new class each time rather than persisting it. If you'd rather a particular direction and want me to do the work, let me know what you'd prefer.