### PR TITLE
pass null to orderOut to prevent errors

### DIFF
--- a/lib/browser-api.js
+++ b/lib/browser-api.js
@@ -95,7 +95,7 @@ module.exports = function (browserWindow, panel, webview) {
   }
 
   browserWindow.hide = function () {
-    return panel.orderOut()
+    return panel.orderOut(null)
   }
 
   browserWindow.isVisible = function () {


### PR DESCRIPTION
Otherwise I get `ObjC method orderOut: requires 1 argument, but JavaScript passed 0 arguments`