### PR TITLE
add more color classes to support old OS

### DIFF
--- a/lib/browser-api.js
+++ b/lib/browser-api.js
@@ -2,6 +2,8 @@ var ObjCClass = require('cocoascript-class').default
 
 var COLOR_CLASSES = [
   'NSColor',
+  'NSCachedWhiteColor',
+  'NSColorSpaceColor',
   'NSDynamicSystemColor',
   'NSCachedColorSpaceColor',
 ]


### PR DESCRIPTION
There are some more valid subclasses for an `NSColor` on El Capitain