### PR TITLE
Only dispatch event if element exists

### DIFF
--- a/lib/dispatch-first-click.js
+++ b/lib/dispatch-first-click.js
@@ -17,7 +17,7 @@ module.exports = function(webView, event) {
     'el.focus' +
     ') {' +
     'el.focus();' + // so focus them
-    '} else {' +
+    '} else if (el) {' +
     'el.dispatchEvent(new Event("click", {bubbles: true}))' + // click the others
     '}'
   )


### PR DESCRIPTION
This is a followup to 1f5531546cad273b85026e92e57fd71705b8e6aa

As written, when `el` is null, it will fall back to the else case, which also references `el`. This adds the additional condition of `el` being truthy to execute `dispatchEvent`.