### PR TITLE
open links in browser

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ export default function() {
 * [Communicating between the Plugin and the WebView](/docs/communication-plugin-webview.md)
 * [Inspecting the WebView](/docs/inspecting-the-webview.md)
 * [Frameless-window](/docs/frameless-window.md)
+* [Opening links in browser](/docs/opening-links-in-browser.md)
 
 ## API References
 

--- a/docs/opening-links-in-browser.md
+++ b/docs/opening-links-in-browser.md
@@ -1,0 +1,28 @@
+# Opening a link from WebView in a default browser
+
+It is impossible to open a link from WebView in external browser directly.
+To achieve that you need 2 parts:
+
+1. In webview - intercept a click event on a link:
+
+```js
+function interceptClickEvent (event) {
+    const target = event.target.closest('a');
+    if (target && target.getAttribute('target') === '_blank') {
+        event.preventDefault();
+        window.postMessage('externalLinkClicked', target.href)
+    }
+}
+
+// listen for link click events at the document level
+document.addEventListener('click', interceptClickEvent);
+```
+
+2. In the host of the plugin - handle the opening:
+
+```js
+webview.webContent.on('externalLinkClicked', url => {
+    NSWorkspace.sharedWorkspace().openURL(NSURL.URLWithString(url))
+});
+
+```

--- a/docs/opening-links-in-browser.md
+++ b/docs/opening-links-in-browser.md
@@ -1,9 +1,10 @@
-# Opening a link from WebView in a default browser
+# Opening an external link in the default browser instead of the WebView
 
-It is impossible to open a link from WebView in external browser directly.
+A link with a `target="_blank"` will have no effect by default in the WebView. In order to open an external link, we will need to go through the Sketch Plugin.
+
 To achieve that you need 2 parts:
 
-1. In webview - intercept a click event on a link:
+1. In the WebView - intercept click events on a link:
 
 ```js
 function interceptClickEvent (event) {
@@ -18,11 +19,10 @@ function interceptClickEvent (event) {
 document.addEventListener('click', interceptClickEvent);
 ```
 
-2. In the host of the plugin - handle the opening:
+2. In the Sketch Plugin - handle the click:
 
 ```js
 webview.webContent.on('externalLinkClicked', url => {
     NSWorkspace.sharedWorkspace().openURL(NSURL.URLWithString(url))
 });
-
 ```


### PR DESCRIPTION
ref: https://github.com/skpm/sketch-module-web-view/issues/67

[this line](https://github.com/skpm/sketch-module-web-view/pull/69/files#diff-d07780b7b0dce42f7001c4a396b12035R10) handles the case where a child of a link (`<a>` tag) was clicked, e.g.:
```html
    <a href="http://example.com"><i class="fa fa-link"></i></a>
```