### PR TITLE
Updated documentation on message passing.

### DIFF
--- a/docs/communication-plugin-webview.md
+++ b/docs/communication-plugin-webview.md
@@ -26,6 +26,19 @@ browserWindow.webContents
   })
 ```
 
+>> Note that values passed to functions within `.executeJavaScript()` must be strings. To pass an object use `JSON.stringify()`
+
+For example :
+```js
+let someObject = { a: "someValue", b: 5 }
+browserWindow.webContents
+  .executeJavaScript(`someGlobalFunctionDefinedInTheWebview(${JSON.stringify(someObject)})`)
+  .then(res => {
+    // do something with the result
+  })
+```
+
+
 ## Sending a message to the WebView from another plugin or command
 
 If you do not have access to the WebView instance (because it was created in another command for example), you can still send a message by using the `id` used to create the WebView.

--- a/docs/communication-plugin-webview.md
+++ b/docs/communication-plugin-webview.md
@@ -38,7 +38,6 @@ browserWindow.webContents
 >    })
 >  ```
 
-
 ## Sending a message to the WebView from another plugin or command
 
 If you do not have access to the WebView instance (because it was created in another command for example), you can still send a message by using the `id` used to create the WebView.

--- a/docs/communication-plugin-webview.md
+++ b/docs/communication-plugin-webview.md
@@ -26,17 +26,17 @@ browserWindow.webContents
   })
 ```
 
->> Note that values passed to functions within `.executeJavaScript()` must be strings. To pass an object use `JSON.stringify()`
-
-For example :
-```js
-let someObject = { a: "someValue", b: 5 }
-browserWindow.webContents
-  .executeJavaScript(`someGlobalFunctionDefinedInTheWebview(${JSON.stringify(someObject)})`)
-  .then(res => {
-    // do something with the result
-  })
-```
+> Note that values passed to functions within `.executeJavaScript()` must be strings. To pass an object use `JSON.stringify()`
+>
+> For example :
+>  ```js
+>  let someObject = { a: "someValue", b: 5 }
+>  browserWindow.webContents
+>    .executeJavaScript(`someGlobalFunctionDefinedInTheWebview(${JSON.stringify(someObject)})`)
+>    .then(res => {
+>      // do something with the result
+>    })
+>  ```
 
 
 ## Sending a message to the WebView from another plugin or command


### PR DESCRIPTION
Make it clear that messages passed to the Webview must be strings. Sketch crashes if you try and send a unstringified object. I lost hours working this out. 