### PR TITLE
Wrong webview is obtained when inspector is open

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -318,7 +318,7 @@ BrowserWindow.fromPanel = function(panel, identifier) {
   var webView = null
   var subviews = panel.contentView().subviews()
   for (var i = 0; i < subviews.length; i += 1) {
-    if (!webView && subviews[i].isKindOfClass(WKWebView)) {
+    if (!webView && !subviews[i].isKindOfClass(WKInspectorWKWebView) && subviews[i].isKindOfClass(WKWebView)) {
       webView = subviews[i]
     }
   }

--- a/remote.js
+++ b/remote.js
@@ -18,7 +18,7 @@ module.exports.sendToWebview = function sendToWebview(identifier, evalString) {
   var webview = null
   var subviews = panel.contentView().subviews()
   for (var i = 0; i < subviews.length; i += 1) {
-    if (!webview && subviews[i].isKindOfClass(WKWebView)) {
+    if (!webview && !subviews[i].isKindOfClass(WKInspectorWKWebView) && subviews[i].isKindOfClass(WKWebView)) {
       webview = subviews[i]
     }
   }


### PR DESCRIPTION
If you have the inspector open in your webview you can have 2 subviews, one of them being a WKInspectorWKWebView.  This view should be ignored so messages are sent to the correct webview.