### PR TITLE
fix draggable region

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,10 +57,14 @@ function BrowserWindow(options) {
   var useStandardWindow = options.windowType !== 'textured'
   var styleMask = NSTitledWindowMask
 
-  // this is commented out because the toolbar doesn't appear otherwise :thinking-face:
-  // if (!useStandardWindow || options.frame === false) {
-  //   styleMask = NSFullSizeContentViewWindowMask
-  // }
+  // prevent the title bar from covering the draggable region
+  if (
+    !useStandardWindow ||
+    (options.frame === false &&
+      (!options.titleBarStyle || options.titleBarStyle === 'default'))
+  ) {
+    styleMask = NSFullSizeContentViewWindowMask
+  }
   if (options.minimizable !== false) {
     styleMask |= NSMiniaturizableWindowMask
   }
@@ -239,18 +243,6 @@ function BrowserWindow(options) {
     // The fullscreen button should always be hidden for frameless window.
     if (panel.standardWindowButton(NSWindowFullScreenButton)) {
       panel.standardWindowButton(NSWindowFullScreenButton).setHidden(true)
-    }
-
-    if (!options.titleBarStyle || options.titleBarStyle === 'default') {
-      // Hide the window buttons.
-      panel.standardWindowButton(NSWindowZoomButton).setHidden(true)
-      panel.standardWindowButton(NSWindowMiniaturizeButton).setHidden(true)
-      panel.standardWindowButton(NSWindowCloseButton).setHidden(true)
-
-      // Some third-party macOS utilities check the zoom button's enabled state to
-      // determine whether to show custom UI on hover, so we disable it here to
-      // prevent them from doing so in a frameless app window.
-      panel.standardWindowButton(NSWindowZoomButton).setEnabled(false)
     }
   }
 

--- a/lib/movable-area.js
+++ b/lib/movable-area.js
@@ -18,22 +18,26 @@ module.exports.injectScript = function(webView) {
     CONSTANTS.START_MOVING_WINDOW +
     '");' +
     "  document.addEventListener('mouseup', onMouseUp);" +
-    '  animationId = requestAnimationFrame(moveWindow);' +
+    "  document.addEventListener('mousemove', onMouseMove);" +
     '};' +
     '' +
     'function onMouseUp(e) {' +
+    "  document.removeEventListener('mousemove', onMouseMove);" +
+    "  document.removeEventListener('mouseup', onMouseUp);" +
     '  window.postMessage("' +
     CONSTANTS.STOP_MOVING_WINDOW +
     '");' +
-    "  document.removeEventListener('mouseup', onMouseUp);" +
-    '  cancelAnimationFrame(animationId);' +
     '};' +
     '' +
-    'function moveWindow(e) {' +
+    'function onMouseMove(e) {' +
+    '  if (!animationId) { animationId = window.requestAnimationFrame(moveWindow) }' +
+    '};' +
+    '' +
+    'function moveWindow() {' +
+    '  animationId = null;' +
     '  window.postMessage("' +
     CONSTANTS.MOVE_WINDOW +
     '");' +
-    '  animationId = requestAnimationFrame(moveWindow);' +
     '}' +
     '})()'
   var script = WKUserScript.alloc().initWithSource_injectionTime_forMainFrameOnly(


### PR DESCRIPTION
Though the title bar is hidden, it exists and covers the top region of the window; 
We will lose mouse events outside the title bar if `mousedown` is fired on it.

If the draggable region is not covered, mouse events are fired even if the mouse is outside the window.
Setting window style mask to `NSFullSizeContentViewWindowMask` may fix this.

e.g. Creating two draggable regions: one is covered by the title bar but the other is not

![draggable](https://user-images.githubusercontent.com/8097302/58002816-01b86400-7b12-11e9-9d8e-948c633b34f0.gif)
