### PR TITLE
cancel animation frame before requesting another

### DIFF
--- a/lib/movable-area.js
+++ b/lib/movable-area.js
@@ -3,7 +3,6 @@ var CONSTANTS = require('./constants')
 module.exports.injectScript = function(webView) {
   var source =
     '(function () {' +
-    'var animationId = null;' +
     "document.addEventListener('mousedown', onMouseDown);" +
     '' +
     'function shouldDrag(target) {' +
@@ -18,8 +17,6 @@ module.exports.injectScript = function(webView) {
     CONSTANTS.START_MOVING_WINDOW +
     '");' +
     "  document.addEventListener('mouseup', onMouseUp);" +
-    '  if (animationId) { cancelAnimationFrame(animationId) }' +
-    '  animationId = requestAnimationFrame(moveWindow);' +
     '};' +
     '' +
     'function onMouseUp(e) {' +
@@ -27,16 +24,8 @@ module.exports.injectScript = function(webView) {
     CONSTANTS.STOP_MOVING_WINDOW +
     '");' +
     "  document.removeEventListener('mouseup', onMouseUp);" +
-    '  cancelAnimationFrame(animationId);' +
-    '  animationId = null;' +
     '};' +
     '' +
-    'function moveWindow(e) {' +
-    '  window.postMessage("' +
-    CONSTANTS.MOVE_WINDOW +
-    '");' +
-    '  animationId = requestAnimationFrame(moveWindow);' +
-    '}' +
     '})()'
   var script = WKUserScript.alloc().initWithSource_injectionTime_forMainFrameOnly(
     source,
@@ -52,30 +41,42 @@ module.exports.injectScript = function(webView) {
 module.exports.setupHandler = function(browserWindow) {
   var initialMouseLocation = null
   var initialWindowPosition = null
+  var timeout = null
+
+  function stopMovingWindow() {
+    initialMouseLocation = null
+    initialWindowPosition = null
+    clearTimeout(timeout)
+  }
+
+  function moveWindow() {
+    if (!initialWindowPosition) {
+      return
+    }
+    if (NSEvent.pressedMouseButtons() !== 1) {
+      stopMovingWindow()
+    } else {
+      var mouse = NSEvent.mouseLocation()
+      browserWindow.setPosition(
+        initialWindowPosition.x + (mouse.x - initialMouseLocation.x),
+        initialWindowPosition.y + (initialMouseLocation.y - mouse.y), // y is inverted
+        false
+      )
+      timeout = setTimeout(moveWindow, 1000 / 60)
+    }
+  }
 
   browserWindow.webContents.on(CONSTANTS.START_MOVING_WINDOW, function() {
+    stopMovingWindow()
+
     initialMouseLocation = NSEvent.mouseLocation()
     var position = browserWindow.getPosition()
     initialWindowPosition = {
       x: position[0],
       y: position[1],
     }
+    timeout = setTimeout(moveWindow, 1000 / 60)
   })
 
-  browserWindow.webContents.on(CONSTANTS.STOP_MOVING_WINDOW, function() {
-    initialMouseLocation = null
-    initialWindowPosition = null
-  })
-
-  browserWindow.webContents.on(CONSTANTS.MOVE_WINDOW, function() {
-    if (!initialWindowPosition) {
-      return
-    }
-    const mouse = NSEvent.mouseLocation()
-    browserWindow.setPosition(
-      initialWindowPosition.x + (mouse.x - initialMouseLocation.x),
-      initialWindowPosition.y + (initialMouseLocation.y - mouse.y), // y is inverted
-      false
-    )
-  })
+  browserWindow.webContents.on(CONSTANTS.STOP_MOVING_WINDOW, stopMovingWindow)
 }

--- a/lib/movable-area.js
+++ b/lib/movable-area.js
@@ -18,6 +18,7 @@ module.exports.injectScript = function(webView) {
     CONSTANTS.START_MOVING_WINDOW +
     '");' +
     "  document.addEventListener('mouseup', onMouseUp);" +
+    '  if (animationId) { cancelAnimationFrame(animationId) }' +
     '  animationId = requestAnimationFrame(moveWindow);' +
     '};' +
     '' +
@@ -27,6 +28,7 @@ module.exports.injectScript = function(webView) {
     '");' +
     "  document.removeEventListener('mouseup', onMouseUp);" +
     '  cancelAnimationFrame(animationId);' +
+    '  animationId = null;' +
     '};' +
     '' +
     'function moveWindow(e) {' +


### PR DESCRIPTION
Moving mouse in every animation frame works better than listening on `onmousemove` event because of the hidden title bar.