### PR TITLE
Correctly load file URLs when prepended with file://

### DIFF
--- a/lib/browser-api.js
+++ b/lib/browser-api.js
@@ -450,8 +450,8 @@ module.exports = function(browserWindow, panel, webview) {
 
     if (/^file:\/\/.*\.html?$/.test(url)) {
       webview.loadFileURL_allowingReadAccessToURL(
-        NSURL.fileURLWithPath(url),
-        NSURL.fileURLWithPath('file:///')
+        NSURL.URLWithString(url),
+        NSURL.URLWithString('file:///')
       )
       return
     }


### PR DESCRIPTION
In macOS 10.15 Catalina, [the API for NSURL changed](https://developer.apple.com/documentation/foundation/nsurl?changes=latest_minor&language=objc). Specifically, `NSURL.fileURLWithPath` now prepends an extra `file:/` to URLs such that `file:///**/*.html` becomes `file://file:/**/*.html`.

Besides, `fileURLWithPath()` was always intended to accept a macOS _path_, not a fully-formed `file://` URL — so it is more sensible to use `NSURL.URLWithString` in this case.

After fixing this, my web views worked with macOS 10.15 Beta (19A526h) and Sketch 57.