### PR TITLE
allow windows to close on MacOS 10.15

### DIFF
--- a/lib/set-delegates.js
+++ b/lib/set-delegates.js
@@ -61,13 +61,13 @@ module.exports = function(browserWindow, panel, webview, options) {
       },
 
       'windowShouldClose:': function() {
-        var shouldClose = true
+        var shouldClose = 1
         this.utils.emit('close', {
           get defaultPrevented() {
             return !shouldClose
           },
           preventDefault: function() {
-            shouldClose = false
+            shouldClose = 0
           },
         })
         return shouldClose


### PR DESCRIPTION
It seems like Catalina doesn't like `true` and `false` for `YES` and `NO`. Changed them to 0 and 1 and it works :)


fixes #119 