### PR TITLE
switch back to queryallowed to prevent encoding colon

### DIFF
--- a/lib/browser-api.js
+++ b/lib/browser-api.js
@@ -452,7 +452,7 @@ module.exports = function(browserWindow, panel, webview) {
       // ensure URLs containing spaces are properly handled
       url = NSString.alloc().initWithString(url)
       url = url.stringByAddingPercentEncodingWithAllowedCharacters(
-        NSCharacterSet.URLPathAllowedCharacterSet()
+        NSCharacterSet.URLQueryAllowedCharacterSet()
       )
       webview.loadFileURL_allowingReadAccessToURL(
         NSURL.URLWithString(url),


### PR DESCRIPTION
Sorry! I goofed #120 by switching to `URLPathAllowedCharacterSet` without testing it. `URLQueryAllowedCharacterSet` works better