### PR TITLE
Un-hide BrowserWindow documentation

### DIFF
--- a/docs/browser-window.md
+++ b/docs/browser-window.md
@@ -126,7 +126,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     - `plugins` Boolean (optional) - Whether plugins should be enabled. Default is `false`.
     - `minimumFontSize` Integer (optional) - Defaults to `0`.
     - `zoomFactor` Number (optional) - The default zoom factor of the page, `3.0` represents `300%`. Default is `1.0`.
-      <!-- - `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default is `true`.
+<!-- 
+  - `nodeIntegration` Boolean (optional) - Whether node integration is enabled. Default is `true`.
   - `nodeIntegrationInWorker` Boolean (optional) - Whether node integration is enabled in web workers. Default is `false`. More about this can be found in [Multithreading](../tutorial/multithreading.md).
   - `preload` String (optional) - Specifies a script that will be loaded before other scripts run in the page. This script will always have access to node APIs no matter whether node integration is turned on or off. The value should be the absolute file path to the script. When node integration is turned off, the preload script can reintroduce Node global symbols back to the global scope. See example [here](process.md#event-loaded).
   - `sandbox` Boolean (optional) - If set, this will sandbox the renderer associated with the window, making it compatible with the Chromium OS-level sandbox and disabling the Node.js engine. This is not the same as the `nodeIntegration` option and the APIs available to the preload script are more limited. Read more about the option [here](sandbox-option.md). **Note:** This option is currently experimental and may change or be removed in future Electron releases.
@@ -161,7 +162,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   - `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md). Defaults to the value of the `nodeIntegration` option. **Note:** The `preload` script configured for the `<webview>` will have node integration enabled when it is executed so you should ensure remote/untrusted content is not able to create a `<webview>` tag with a possibly malicious `preload` script. You can use the `will-attach-webview` event on [webContents](web-contents.md) to strip away the `preload` script and to validate or alter the `<webview>`'s initial settings.
   - `additionalArguments` String[](optional) - A list of strings that will be appended to `process.argv` in the renderer process of this app. Useful for passing small bits of data down to renderer process preload scripts.
   - `safeDialogs` Boolean (optional) - Whether to enable browser style consecutive dialog protection. Default is `false`.
-  - `safeDialogsMessage` String (optional) - The message to display when consecutive dialog protection is triggered. If not defined the default message would be used, note that currently the default message is in English and not localized. -->
+  - `safeDialogsMessage` String (optional) - The message to display when consecutive dialog protection is triggered. If not defined the default message would be used, note that currently the default message is in English and not localized.
+-->
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/ `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from passing a size that does not follow size constraints to `setBounds`/`setSize` or to the constructor of `BrowserWindow`.
 


### PR DESCRIPTION
Everything from “When setting minimum or maximum window size…” until the `closed` event was hidden by GitHub even though it was _not_ commented out. It also messed up the indentation of the page after that. Changing the comments a little seems to fix it.