### PR TITLE
fix parseHexColor

### DIFF
--- a/lib/browser-api.js
+++ b/lib/browser-api.js
@@ -33,10 +33,10 @@ function parseHexColor(color) {
     return NSColor.whiteColor()
   }
 
-  var r = parseInt(hex.slice(0, 2), 16)
-  var g = parseInt(hex.slice(2, 4), 16)
-  var b = parseInt(hex.slice(4, 6), 16)
-  var a = parseInt(hex.slice(6, 8), 16)
+  var r = parseInt(hex.slice(0, 2), 16) / 255
+  var g = parseInt(hex.slice(2, 4), 16) / 255
+  var b = parseInt(hex.slice(4, 6), 16) / 255
+  var a = parseInt(hex.slice(6, 8), 16) / 255
 
   return NSColor.colorWithSRGBRed_green_blue_alpha(r, g, b, a)
 }


### PR DESCRIPTION
`backgroundColor` option is not working properly because of `parseHexColor`.

It seems that the parameters of `NSColor.colorWithSRGBRed_green_blue_alpha` need to be `float`s between 0 to 1.

----
Interestingly (or not) the discussion part
> Values below 0.0 are interpreted as 0.0, and values above 1.0 are interpreted as 1.0.

of the [document](https://developer.apple.com/documentation/appkit/nscolor/1532666-colorwithsrgbred?language=objc) is NOT true in `macOS Catalina (10.15.1)`.

`parseHexColor('#ffffffff')` got this:

![image](https://user-images.githubusercontent.com/8097302/68099350-0379b680-fefd-11e9-8685-48a9e946ab84.png)
