### PR TITLE
fix light / dark theme observer

### DIFF
--- a/lib/set-delegates.js
+++ b/lib/set-delegates.js
@@ -35,16 +35,15 @@ module.exports = function(browserWindow, panel, webview, options) {
     ThemeObserverClass = new ObjCClass({
       utils: null,
 
-      'observeValueForKeyPath:ofObject:change:context:': function() {
+      'observeValueForKeyPath:ofObject:change:context:': function(keyPath,object,change) {
+        const newAppearance = change[NSKeyValueChangeNewKey]
+        const isDark = String(newAppearance.bestMatchFromAppearancesWithNames(['NSAppearanceNameAqua', 'NSAppearanceNameDarkAqua'])) === 'NSAppearanceNameDarkAqua'
+
         this.utils.executeJavaScript(
           "document.body.classList.remove('__skpm-" +
-            (typeof MSTheme !== 'undefined' && MSTheme.sharedTheme().isDark()
-              ? 'light'
-              : 'dark') +
+            (isDark ? 'light' : 'dark') +
             "'); document.body.classList.add('__skpm-" +
-            (typeof MSTheme !== 'undefined' && MSTheme.sharedTheme().isDark()
-              ? 'dark'
-              : 'light') +
+            (isDark ? 'dark' : 'light') +
             "')"
         )
       },
@@ -252,7 +251,7 @@ module.exports = function(browserWindow, panel, webview, options) {
   NSApplication.sharedApplication().addObserver_forKeyPath_options_context(
     themeObserver,
     'effectiveAppearance',
-    NSKeyValueChangeNewKey,
+    NSKeyValueObservingOptionNew,
     null
   )
 


### PR DESCRIPTION
The observer should examine the new value being currently set.

**References**: 
https://christiantietze.de/posts/2019/01/nsappearance-dark-mode-change-notification-rxswift/
https://nalexn.github.io/kvo-guide-for-key-value-observing/

**Fixes**: https://github.com/skpm/sketch-module-web-view/issues/158