### PR TITLE
fix type of BrowserWindow.id

### DIFF
--- a/docs/browser-window.md
+++ b/docs/browser-window.md
@@ -85,6 +85,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
 ### `new BrowserWindow([options])`
 
 - `options` Object (optional)
+  - `identifier` String (optional) - Window's unique id. Default is newly generated UUID.
   - `width` Integer (optional) - Window's width in pixels. Default is `800`.
   - `height` Integer (optional) - Window's height in pixels. Default is `600`.
   - `x` Integer (optional) (**required** if y is used) - Window's left offset from screen. Default is to center the window.
@@ -326,7 +327,7 @@ Returns `BrowserWindow | null` - The window that owns the given `browserView`. I
 
 #### `BrowserWindow.fromId(id)`
 
-- `id` Integer
+- `id` String
 
 Returns `BrowserWindow` - The window with the given `id`.
 
@@ -419,7 +420,7 @@ See the [`webContents` documentation](web-contents.md) for its methods and event
 
 #### `win.id`
 
-A `Integer` representing the unique ID of the window.
+A `String` representing the unique ID of the window.
 
 ### Instance Methods
 

--- a/type.d.ts
+++ b/type.d.ts
@@ -322,7 +322,7 @@ declare module "sketch-module-web-view" {
     constructor(options?: BrowserWindowOptions);
 
     /** Return window with the given id */
-    static fromId(id: number): BrowserWindow;
+    static fromId(id: string): BrowserWindow;
 
     /**
      * A `WebContents` object this window owns. All web page related events and
@@ -331,7 +331,7 @@ declare module "sketch-module-web-view" {
     webContents: WebContents;
 
     /** An integer representing the unique ID of the window. */
-    id: number;
+    id: string;
 
     /**
      * Force closing the window, the `unload` and `beforeunload` event won't be


### PR DESCRIPTION
- Add BrwoserWindowOptions.identifier to docs
- Fix type of BrowserWindow.id in type.d.ts
- Fix type of parameter of BrowserWindow.fromId in type.d.ts
- Resolve #166 