### PR TITLE
Fix missing delegate messages sent to a restored BrowserWindow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -355,6 +355,10 @@ BrowserWindow.fromPanel = function (panel, identifier) {
 
   buildBrowserAPI(browserWindow, panel, webView)
   buildWebAPI(browserWindow, panel, webView)
+  // FIXME: we should be able to provide the actual options here instead of
+  // an empty object, but we can't persist them via NSThread.threadDictionary()
+  // as it's not an Objective-C object
+  setDelegates(browserWindow, panel, webView, {})
 
   return browserWindow
 }


### PR DESCRIPTION
https://forum.sketch.com/t/unable-to-close-plugin-window/4640

Fixes #176